### PR TITLE
ci: allow dependabot to violate commitlint

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    if: github.actor != 'dependabot-preview[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Makes an exception in the GH workflow for PRs for commitlint and dependabot

closes #21